### PR TITLE
feat: checkout to master after update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ or
 ```bash
 $ git clone https://github.com/pacstall/pacup.pl
 $ cd pacup.pl
+$ cpan Data::Compare File::chdir JSON List::MoreUtils Term::ProgressBar
 $ perl Makefile.PL
 $ sudo make install
 ```

--- a/pacup
+++ b/pacup
@@ -597,6 +597,12 @@ sub main ($pkg) {
         system 'gh', ( 'pr', 'create', '--title', $commit_msg, '--body', '' );
     }
 
+    if ( ask
+        'Checkout to master?' )
+    {
+        system 'git', ( 'checkout', 'master');
+    }
+
     info "Done!";
     return 1;
 }


### PR DESCRIPTION
I had to manually checkout to master every time after updating a pacscript.
I accidentally updated 3 pacsripts without checking out to master, ruining latter pacscripts.
This is a small patch to ask if the user wants to checkout to master.